### PR TITLE
Add desktop UI and clone Peggy project, set to user.

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -84,7 +84,7 @@ ls -alh /image_with_kernel_*.tar.gz
 
 # download the ready-made raw image for the RPi
 if [ ! -f "${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" ]; then
-  wget -q -O "${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" "https://github.com/hypriot/image-builder-raw/releases/download/${RAW_IMAGE_VERSION}/${RAW_IMAGE}.zip"
+  wget -q -O "${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" "https://jenkins.laboratoriopublico.org/job/image-builder-raw/ws/${RAW_IMAGE}.zip"
 fi
 
 # verify checksum of the ready-made raw image

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -120,7 +120,7 @@ apt-get update
 # apt-get upgrade -y
 
 # Check free space
-df -h
+df -h /
 
 # install packages
 DEBIAN_FRONTEND=noninteractive apt-get  -o Dpkg::Options::=--force-confdef \

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -120,7 +120,7 @@ apt-get update
 # apt-get upgrade -y
 
 # install packages
-apt-get  -o Dpkg::Options::=--force-confdef \
+DEBIAN_FRONTEND=noninteractive apt-get  -o Dpkg::Options::=--force-confdef \
   install -y \
   --no-install-recommends \
   firmware-atheros \

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -148,7 +148,7 @@ apt-get  -o Dpkg::Options::=--force-confdef \
   lsb-release \
   gettext \
   cloud-init \
-  raspberrypi-ui-mods \
+  pt-ui-mods \
   git
 
 

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -119,6 +119,9 @@ echo 'deb http://archive.raspberrypi.org/debian/ stretch main' | tee /etc/apt/so
 apt-get update
 # apt-get upgrade -y
 
+# Check free space
+df -h
+
 # install packages
 DEBIAN_FRONTEND=noninteractive apt-get  -o Dpkg::Options::=--force-confdef \
   install -y \

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -147,7 +147,9 @@ apt-get  -o Dpkg::Options::=--force-confdef \
   pi-bluetooth \
   lsb-release \
   gettext \
-  cloud-init
+  cloud-init \
+  raspberrypi-ui-mods \
+  git
 
 
 # install special Docker enabled kernel
@@ -220,3 +222,6 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 echo "HYPRIOT_DEVICE=\"$HYPRIOT_DEVICE\"" >> /etc/os-release
 echo "HYPRIOT_IMAGE_VERSION=\"$HYPRIOT_IMAGE_VERSION\"" >> /etc/os-release
 cp /etc/os-release /boot/os-release
+
+# Integrate camera development work (see https://publiclab.org/notes/MaggPi/08-09-2018/raspberry-pi-manual-camera-control )
+git clone https://github.com/MargaretAN9/Peggy/ /home/publiclab/Peggy

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -152,6 +152,7 @@ DEBIAN_FRONTEND=noninteractive apt-get  -o Dpkg::Options::=--force-confdef \
   gettext \
   cloud-init \
   pt-ui-mods \
+  xserver-xorg \
   git
 
 # install special Docker enabled kernel

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -151,7 +151,6 @@ DEBIAN_FRONTEND=noninteractive apt-get  -o Dpkg::Options::=--force-confdef \
   pt-ui-mods \
   git
 
-
 # install special Docker enabled kernel
 if [ -z "${KERNEL_URL}" ]; then
   apt-get install -y \

--- a/builder/files/boot/user-data
+++ b/builder/files/boot/user-data
@@ -68,5 +68,8 @@ runcmd:
   # Pickup the hostname changes
   - 'systemctl restart avahi-daemon'
 
+  # Give ownership of scripts
+  - 'chown publiclab.publiclab /home/publiclab/Peggy -R'
+
 #  # Activate WiFi interface
 #  - 'ifup wlan0'

--- a/versions.config
+++ b/versions.config
@@ -4,8 +4,8 @@ ROOTFS_TAR_CHECKSUM="d1e7e6d48a25b4a206c5df99ecb8815388ec6945e4f97e78413d5a80778
 
 # name of the ready made raw image for RPi
 RAW_IMAGE="rpi-raw.img"
-RAW_IMAGE_VERSION="v0.2.2"
-RAW_IMAGE_CHECKSUM="2fbeb13b7b0f2308dbd0d82780b54c33003ad43d145ff08498b25fb8bbe1c2c6"
+RAW_IMAGE_VERSION="master"
+RAW_IMAGE_CHECKSUM="e32c0b9f3cdb9c60bad97a724103fc1283cdc135848e6142d588cd96fac1d6a8"
 
 # specific versions of kernel/firmware and docker tools
 export KERNEL_BUILD="20180422-141901"


### PR DESCRIPTION
This adds to the internal script the package for a desktop environment and then clones Peggy repository into /home/publiclab/Peggy:

https://github.com/MargaretAN9/Peggy - `Computer Vision enhancements for Raspberry Pi based Public Lab Science Projects`

****

### Download instructions

Generating the image will take a few minutes. Once the image is prepared, and if it succeeded, you'll see a green checkmark at the bottom of the pull request. To download the image:

1. click the green checkmark; you'll go to a page at a URL like `https://gitlab.com/publiclab/image-builder-rpi/pipelines/########/builds`
2. On this page, click the `Jobs` tab, next to `Pipeline`
3. Click the green `Passed` button
4. Click `Download` in the right-hand sidebar
5. Unzip the `artifacts.zip` file, and also the `hypriotos-rpi-camera_web.img.zip` within it
6. Use a program like https://etcher.io/ to flash it to an SD card

You'll also be able to read the output of the image generation in this window.

We hope to create a bot to report back the completed image URL in each pull request. If you can help create such a bot, please contact us at:

https://github.com/publiclab/image-builder-rpi/issues/16

Thanks!