### PR TITLE
Include web terminal

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -205,6 +205,11 @@ lighttpd-enable-mod fastcgi-php
 systemctl disable dhcpcd
 systemctl disable hciuart
 
+echo "Installing ttyd web terminal"
+wget -q https://github.com/tsl0922/ttyd/releases/download/1.4.2/ttyd_linux.armhf -O usr/local/bin/ttyd
+chmod +x usr/local/bin/ttyd
+systemctl enable ttyd
+
 echo "Installing rpi-serial-console script"
 wget -q https://raw.githubusercontent.com/lurch/rpi-serial-console/master/rpi-serial-console -O usr/local/bin/rpi-serial-console
 chmod +x usr/local/bin/rpi-serial-console

--- a/builder/files/etc/systemd/system/ttyd.service
+++ b/builder/files/etc/systemd/system/ttyd.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=ttyd Web Terminal
+
+[Service]
+ExecStart=/usr/local/bin/ttyd login
+
+[Install]
+WantedBy=multi-user.target

--- a/builder/files/var/www/index.html
+++ b/builder/files/var/www/index.html
@@ -16,5 +16,8 @@
         <p>
         <i>You've correctly connected to your Pi!</i>
         </p>
+        <p>
+        <a href="http://pi.local:7681/">Access command line</a>
+        </p>
     </body>
 </html>


### PR DESCRIPTION
This recipe installs a web-based terminal interface accessible over WiFi (network `00-PiCamera`)

****

### Download instructions

Generating the image will take a few minutes. Once the image is prepared, and if it succeeded, you'll see a green checkmark at the bottom of the pull request. To download the image:

1. click the green checkmark; you'll go to a page at a URL like `https://gitlab.com/publiclab/image-builder-rpi/pipelines/########/builds`
2. On this page, click the `Jobs` tab, next to `Pipeline`
3. Click the green `Passed` button
4. Click `Download` in the right-hand sidebar
5. Unzip the `artifacts.zip` file, and also the `hypriotos-rpi-camera_web.img.zip` within it
6. Use a program like https://etcher.io/ to flash it to an SD card

You'll also be able to read the output of the image generation in this window.

We hope to create a bot to report back the completed image URL in each pull request. If you can help create such a bot, please contact us at:

https://github.com/publiclab/image-builder-rpi/issues/16

Thanks!