### PR TITLE
Infragram + web-based RPi Cam software for use with Raspberry Pi camera 

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -84,7 +84,7 @@ ls -alh /image_with_kernel_*.tar.gz
 
 # download the ready-made raw image for the RPi
 if [ ! -f "${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" ]; then
-  wget -q -O "${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" "https://github.com/hypriot/image-builder-raw/releases/download/${RAW_IMAGE_VERSION}/${RAW_IMAGE}.zip"
+  wget -q -O "${BUILD_RESULT_PATH}/${RAW_IMAGE}.zip" "https://jenkins.laboratoriopublico.org/job/image-builder-raw/ws/${RAW_IMAGE}.zip"
 fi
 
 # verify checksum of the ready-made raw image

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -147,6 +147,12 @@ apt-get  -o Dpkg::Options::=--force-confdef \
   pi-bluetooth \
   lsb-release \
   gettext \
+  unzip \
+  zip \
+  libav-tools \
+  gstreamer1.0-tools \
+  motion \
+  gpac \
   cloud-init
 
 
@@ -208,6 +214,14 @@ systemctl disable hciuart
 echo "Installing rpi-serial-console script"
 wget -q https://raw.githubusercontent.com/lurch/rpi-serial-console/master/rpi-serial-console -O usr/local/bin/rpi-serial-console
 chmod +x usr/local/bin/rpi-serial-console
+
+echo "Installing RPi Cam Web Interface"
+wget -q https://github.com/silvanmelchior/RPi_Cam_Web_Interface/archive/master.zip -O /tmp/rpicam.zip
+cd /tmp/
+unzip rpicam.zip
+cd RPi_Cam_Web_Interface-master
+cp /etc/rpicam_config.txt config.txt
+bash ./install.sh q
 
 # fix eth0 interface name
 ln -s /dev/null /etc/systemd/network/99-default.link

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -211,6 +211,21 @@ lighttpd-enable-mod fastcgi-php
 systemctl disable dhcpcd
 systemctl disable hciuart
 
+echo "Installing infragram"
+
+# install npm/node:
+curl -o node-v9.7.1-linux-armv6l.tar.gz https://nodejs.org/dist/v9.7.1/node-v9.7.1-linux-armv6l.tar.gz
+tar -xzf node-v9.7.1-linux-armv6l.tar.gz
+sudo cp -r node-v9.7.1-linux-armv6l/* /usr/local/
+sudo apt-get install git
+
+# install infragram in the web public folder:
+cd /var/www/
+git clone https://github.com/publiclab/infragram.git
+cd infragram
+npm install
+cd /
+
 echo "Installing rpi-serial-console script"
 wget -q https://raw.githubusercontent.com/lurch/rpi-serial-console/master/rpi-serial-console -O usr/local/bin/rpi-serial-console
 chmod +x usr/local/bin/rpi-serial-console

--- a/builder/files/etc/rc.local
+++ b/builder/files/etc/rc.local
@@ -1,0 +1,14 @@
+#!/bin/sh -e
+#
+# rc.local
+#
+# This script is executed at the end of each multiuser runlevel.
+# Make sure that the script will "exit 0" on success or any other
+# value on error.
+#
+# In order to enable or disable this script just change the execution
+# bits.
+#
+# By default this script does nothing.
+
+exit 0

--- a/builder/files/etc/rpicam_config.txt
+++ b/builder/files/etc/rpicam_config.txt
@@ -1,0 +1,8 @@
+rpicamdir="cam"
+webserver=""
+webport="80"
+user=""
+webpasswd=""
+autostart="yes"
+jpglink="no"
+phpversion="7"

--- a/builder/files/var/www/index.html
+++ b/builder/files/var/www/index.html
@@ -26,5 +26,8 @@
     <p>If you're seeing this in a pop-up, close it and open <a href="http://pi.local">http://pi.local</a> in a browser.</p>
     <p>On Android devices, you may have to turn off cellular data to use this in a browser.</p>
 
+    <p><a class="btn" href="http://pi.local/infragram/pi/">Access Infragram software</a></p>
+    <p><a class="btn" href="http://pi.local/cam/">Access the camera</a></p>
+    
   </body>
 </html>

--- a/versions.config
+++ b/versions.config
@@ -4,8 +4,8 @@ ROOTFS_TAR_CHECKSUM="d1e7e6d48a25b4a206c5df99ecb8815388ec6945e4f97e78413d5a80778
 
 # name of the ready made raw image for RPi
 RAW_IMAGE="rpi-raw.img"
-RAW_IMAGE_VERSION="v0.2.2"
-RAW_IMAGE_CHECKSUM="2fbeb13b7b0f2308dbd0d82780b54c33003ad43d145ff08498b25fb8bbe1c2c6"
+RAW_IMAGE_VERSION="master"
+RAW_IMAGE_CHECKSUM="e32c0b9f3cdb9c60bad97a724103fc1283cdc135848e6142d588cd96fac1d6a8"
 
 # specific versions of kernel/firmware and docker tools
 export KERNEL_BUILD="20180422-141901"


### PR DESCRIPTION
(this is a working branch related to #37)

Thanks for opening a pull request! In this repository, opening a PR will initiate the generation of a new Raspberry Pi image, and create an image file you can download and use in your Raspberry Pi.

The changes you add to the pull request, such as adding software to install, will be run on the generated image.

For an example, see the software installed and configured in this pull request: https://github.com/publiclab/image-builder-rpi/pull/15/files

### Recipe

Use this space to describe what your "recipe" is intended to install and configure on a Raspberry Pi:

This runs the [Infragram](https://github.com/publiclab/infragram) multispectral image processing system on board the Pi, sourcing video from the Pi camera, live! Exciting 🛰 🌱 📸 :

![screen shot 2018-10-26 at 4 07 59 pm](https://user-images.githubusercontent.com/24359/47590143-712df280-d939-11e8-9366-457336736d85.png)



****

### Download instructions

Generating the image will take a few minutes. Once the image is prepared, and if it succeeded, you'll see a green checkmark at the bottom of the pull request. To download the image:

1. click the green checkmark; you'll go to a page at a URL like `https://gitlab.com/publiclab/image-builder-rpi/pipelines/########/builds`
2. On this page, click the `Jobs` tab, next to `Pipeline`
3. Click the green `Passed` button
4. Click `Download` in the right-hand sidebar
5. Unzip the `artifacts.zip` file, and also the `hypriotos-rpi-camera_web.img.zip` within it
6. Use a program like https://etcher.io/ to flash it to an SD card

You'll also be able to read the output of the image generation in this window.

We hope to create a bot to report back the completed image URL in each pull request. If you can help create such a bot, please contact us at:

https://github.com/publiclab/image-builder-rpi/issues/16

Thanks!
