### PR TITLE
Install Witty Pi energy manager 

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -147,7 +147,8 @@ apt-get  -o Dpkg::Options::=--force-confdef \
   pi-bluetooth \
   lsb-release \
   gettext \
-  cloud-init
+  cloud-init \
+  git
 
 
 # install special Docker enabled kernel
@@ -220,3 +221,13 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 echo "HYPRIOT_DEVICE=\"$HYPRIOT_DEVICE\"" >> /etc/os-release
 echo "HYPRIOT_IMAGE_VERSION=\"$HYPRIOT_IMAGE_VERSION\"" >> /etc/os-release
 cp /etc/os-release /boot/os-release
+
+# install Witty Pi energy manager
+echo "Installing Witty pi mini packages"
+mkdir /home/wittypi
+git clone https://github.com/uugear/Witty-Pi-2.git /home/wittypi
+chmod +1 /home/wittypi/installWittyPi.sh
+./home/wittypi/installWittyPi.sh
+wget https://gitlab.com/imvec/anoiacam/blob/8dc8b9c798d2d6c79ec4267b90b8175fd84c7682/schedule.wpi /home/wittypi/wittyPi
+rm -rf /home/wittypi/wittyPi/daemon.sh
+wget https://gitlab.com/imvec/anoiacam/blob/11d387a98e0283f91e9ae7118a6456a4360caa7c/daemon.sh /home/wittypi/wittyPi


### PR DESCRIPTION
Thanks for opening a pull request! In this repository, opening a PR will initiate the generation of a new Raspberry Pi image, and create an image file you can download and use in your Raspberry Pi.

The changes you add to the pull request, such as adding software to install, will be run on the generated image.

For an example, see the software installed and configured in this pull request: https://github.com/publiclab/image-builder-rpi/pull/15/files

### Recipe

Use this space to describe what your "recipe" is intended to install and configure on a Raspberry Pi:




****

### Download instructions

Generating the image will take a few minutes. Once the image is prepared, and if it succeeded, you'll see a green checkmark at the bottom of the pull request. To download the image:

1. click the green checkmark; you'll go to a page at a URL like `https://gitlab.com/publiclab/image-builder-rpi/pipelines/########/builds`
2. On this page, click the `Jobs` tab, next to `Pipeline`
3. Click the green `Passed` button
4. Click `Download` in the right-hand sidebar
5. Unzip the `artifacts.zip` file, and also the `hypriotos-rpi-camera_web.img.zip` within it
6. Use a program like https://etcher.io/ to flash it to an SD card

You'll also be able to read the output of the image generation in this window.

We hope to create a bot to report back the completed image URL in each pull request. If you can help create such a bot, please contact us at:

https://github.com/publiclab/image-builder-rpi/issues/16

Thanks!
