### PR TITLE
Witty pi energy manager software

### DIFF
--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -227,7 +227,7 @@ mkdir /home/wittypi
 git clone https://github.com/uugear/Witty-Pi-2.git /home/wittypi
 chmod +1 /home/wittypi/installWittyPi.sh
 ./home/wittypi/installWittyPi.sh
-wget https://gitlab.com/imvec/anoiacam/blob/8dc8b9c798d2d6c79ec4267b90b8175fd84c7682/schedule.wpi /home/wittypi/wittyPi
+wget https://github.com/imvectech/miscelaneous/blob/master/schedule.wpi /home/wittypi/wittyPi
 rm -rf /home/wittypi/wittyPi/daemon.sh
-wget https://gitlab.com/imvec/anoiacam/blob/11d387a98e0283f91e9ae7118a6456a4360caa7c/daemon.sh /home/wittypi/wittyPi
+wget https://github.com/imvectech/miscelaneous/blob/master/daemon.sh /home/wittypi/wittyPi
 

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -220,3 +220,14 @@ rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 echo "HYPRIOT_DEVICE=\"$HYPRIOT_DEVICE\"" >> /etc/os-release
 echo "HYPRIOT_IMAGE_VERSION=\"$HYPRIOT_IMAGE_VERSION\"" >> /etc/os-release
 cp /etc/os-release /boot/os-release
+
+# Install witty pi software
+echo "Installing Witty pi mini packages"
+mkdir /home/wittypi
+git clone https://github.com/uugear/Witty-Pi-2.git /home/wittypi
+chmod +1 /home/wittypi/installWittyPi.sh
+./home/wittypi/installWittyPi.sh
+wget https://gitlab.com/imvec/anoiacam/blob/8dc8b9c798d2d6c79ec4267b90b8175fd84c7682/schedule.wpi /home/wittypi/wittyPi
+rm -rf /home/wittypi/wittyPi/daemon.sh
+wget https://gitlab.com/imvec/anoiacam/blob/11d387a98e0283f91e9ae7118a6456a4360caa7c/daemon.sh /home/wittypi/wittyPi
+


### PR DESCRIPTION
###  WHAT
![011](https://user-images.githubusercontent.com/22200702/47939253-e889f600-dee6-11e8-9865-ef53b6cc411e.jpg)

Witty pi mini is a Uugear RPi shield capable of managing energy of the RPi together with keeping time using an embedded RTC.

https://github.com/uugear/Witty-Pi-2

We are working on a timelapse camera for river monitoring. The intention is to turn on the rpi 5 minutes every hour and take a picture. Simple as that. The Witty pi controls the On/OFF of the RPi sending zero voltage to the Pi to fully turn it off. After 55 minutes the Witty sends a electrical signal and the Pi boots up.

We've already done this using raspbian and want to use the PL camera kit instead ;D

In the recipe we also include a pythin script for the timelapse and some packages needed.

### Download instructions

Generating the image will take a few minutes. Once the image is prepared, and if it succeeded, you'll see a green checkmark at the bottom of the pull request. To download the image:

1. click the green checkmark; you'll go to a page at a URL like `https://gitlab.com/publiclab/image-builder-rpi/pipelines/########/builds`
2. On this page, click the `Jobs` tab, next to `Pipeline`
3. Click the green `Passed` button
4. Click `Download` in the right-hand sidebar
5. Unzip the `artifacts.zip` file, and also the `hypriotos-rpi-camera_web.img.zip` within it
6. Use a program like https://etcher.io/ to flash it to an SD card

You'll also be able to read the output of the image generation in this window.

We hope to create a bot to report back the completed image URL in each pull request. If you can help create such a bot, please contact us at:

https://github.com/publiclab/image-builder-rpi/issues/16

Thanks!
